### PR TITLE
Yet another bugfix

### DIFF
--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -61,12 +61,7 @@ public class SpectateListener implements Listener {
 		if (plugin.specChat) {
 			if (plugin.user.get(event.getPlayer().getName()).spectating) {
 				event.setCancelled(true);
-				for (Player player : plugin.getServer().getOnlinePlayers()) {
-					if(plugin.user.get(player.getName()).spectating) {
-						player.sendMessage(ChatColor.GRAY + "[SPEC] " + event.getPlayer().getDisplayName() + ChatColor.GRAY + ": " + event.getMessage());
-					}
-				}
-				plugin.console.sendMessage(ChatColor.GRAY + "[SPEC] " + event.getPlayer().getDisplayName() + ChatColor.GRAY + ": " + event.getMessage());
+				plugin.sendSpectatorMessage(event.getPlayer(), event.getMessage(), false);
 			}
 		}
 	}
@@ -217,10 +212,16 @@ public class SpectateListener implements Listener {
 	}
 	@EventHandler
 	void onCommandPreprocess(PlayerCommandPreprocessEvent event) {
+		if(plugin.specChat && event.getMessage().startsWith("/me")) {
+			plugin.sendSpectatorMessage(event.getPlayer(), event.getMessage().substring(4), true);
+			event.setCancelled(true);
+			return;
+		}
+		
 		if (plugin.blockCmds) {
-			if (event.getPlayer().hasPermission("spectate.admin")&&plugin.adminBypass) {
+			if (event.getPlayer().hasPermission("spectate.admin") && plugin.adminBypass) {
 				// Do nothing
-			} else if (!(event.getMessage().startsWith("/spec")||event.getMessage().startsWith("/spectate")) && plugin.user.get(event.getPlayer().getName()).spectating) {
+			} else if (!(event.getMessage().startsWith("/spec") || event.getMessage().startsWith("/spectate") || event.getMessage().startsWith("/me")) && plugin.user.get(event.getPlayer().getName()).spectating) {
 				event.getPlayer().sendMessage(plugin.prefix+"Command blocked!");
 				event.setCancelled(true);
 			}

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
@@ -670,4 +670,26 @@ public class SpectatorPlus extends JavaPlugin {
 		}
 		console.sendMessage(formattedMessage);
 	}
+	void sendSpectatorMessage(CommandSender sender, String message, Boolean isAction) {
+		String playerName = null;
+		if(sender instanceof Player) {
+			playerName = ((Player) sender).getDisplayName();
+		} else {
+			playerName = "CONSOLE";
+		}
+		
+		String invite = null;
+		if(isAction) {
+			invite = "* " + playerName + " ";
+		} else {
+			invite = playerName + ChatColor.GRAY + ": ";
+		}
+		
+		for (Player player : getServer().getOnlinePlayers()) {
+			if(user.get(player.getName()).spectating) {
+				player.sendMessage(ChatColor.GRAY + "[SPEC] " + invite + ChatColor.GRAY + message);
+			}
+		}
+		console.sendMessage(ChatColor.GRAY + "[SPEC] " + invite + ChatColor.GRAY + message);
+	}
 }


### PR DESCRIPTION
The action messages (`/me <message>`) are not blocked by the command blocker, and hidden to the non-spectators if the spectator chat is enabled.
