### PR TITLE
The spectators are not hit by projectiles (ticket 11)

### DIFF
--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -1,5 +1,9 @@
 package com.pgcraft.spectatorplus;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -9,6 +13,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.ThrownPotion;
@@ -24,7 +29,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
-import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
@@ -39,7 +43,6 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
@@ -113,7 +116,7 @@ public class SpectateListener implements Listener {
 	/**
 	 * Used to:
 	 *  - cancel any damage taken or caused by a spectator;
-	 *  - make arrows, snowballs and negative potions flew by the spectators.
+	 *  - make non-potions projectiles flew by the spectators.
 	 * 
 	 * @param event
 	 */
@@ -181,9 +184,116 @@ public class SpectateListener implements Listener {
 		}
 	}
 	
-	@EventHandler
-	protected void onPotionSplash(PotionSplashEvent ev) {
+	/**
+	 * Used to make splash potions flew by the spectators.
+	 * 
+	 * @param event
+	 */
+	@EventHandler(priority = EventPriority.HIGHEST)
+	protected void onPotionSplash(final PotionSplashEvent event) {
 		
+		final ArrayList<UUID> spectatorsAffected = new ArrayList<UUID>();
+		
+		for(LivingEntity player : event.getAffectedEntities()) {
+			if(player instanceof Player && plugin.user.get(((Player) player).getName()).spectating) {
+				spectatorsAffected.add(player.getUniqueId());
+			}
+		}
+		
+		// If there isn't any spectator affected, it's a splash on players only and the spectators cannot
+		// affect the behavior of the potion.
+		// So, in this case, we don't care about the event.
+		if(!spectatorsAffected.isEmpty()) {
+			
+			// If there is some spectators involved, we try to find how they are involved.
+			// If all the spectators involved are far away from the impact point, there isn't
+			// any needed action.
+			// Else, if a spectator is the impact point, he perturbed the launch of the potion, and
+			// the same thing is done as for the non-potions projectiles (teleport the spectators up, etc.).
+			// In all cases, the effect is removed from the spectators.
+			
+			Boolean teleportationNeeded = false;
+			
+			for(Entity entity : event.getEntity().getNearbyEntities(2, 2, 2)) {
+				if(entity instanceof Player && plugin.user.get(((Player) entity).getName()).spectating) {
+					// The potion hits a spectator
+					teleportationNeeded = true;
+				}
+			}
+			
+			final HashMap<UUID,Boolean> oldFlyMode = new HashMap<UUID,Boolean>(); 
+			
+			for(UUID spectatorUUID : spectatorsAffected) {
+				
+				Player spectator = plugin.getServer().getPlayer(spectatorUUID);
+				
+				// The effect is removed
+				event.setIntensity(spectator, 0);
+				
+				if(teleportationNeeded) {
+					oldFlyMode.put(spectator.getUniqueId(), spectator.isFlying());
+					spectator.setFlying(true);
+
+					// High teleportation because the potions can be thrown up
+					spectator.teleport(spectator.getLocation().add(0, 10, 0));
+				}
+			}
+			
+			if(teleportationNeeded) {
+				
+				final Location initialProjectileLocation = event.getEntity().getLocation();
+				final Vector initialProjectileVelocity = event.getEntity().getVelocity();
+				
+				// Prevents the potion from splashing on the entity
+				Bukkit.getScheduler().runTaskLater(plugin, new BukkitRunnable() {
+					@Override
+					public void run() {
+						// Because the original entity is, one tick later, destroyed, we need to spawn a new one
+						// Cancelling the event only cancels the effect.
+						ThrownPotion clonedEntity = (ThrownPotion) event.getEntity().getWorld().spawnEntity(initialProjectileLocation, event.getEntity().getType()); 
+						
+						// For other plugins (may be used)
+						clonedEntity.setShooter(event.getEntity().getShooter());
+						clonedEntity.setTicksLived(event.getEntity().getTicksLived());
+						clonedEntity.setFallDistance(event.getEntity().getFallDistance());
+						clonedEntity.setBounce(event.getEntity().doesBounce());
+						if(event.getEntity().getPassenger() != null) {
+							clonedEntity.setPassenger(event.getEntity().getPassenger()); // hey, why not
+						}
+						
+						// Clones the effects
+						clonedEntity.setItem(event.getEntity().getItem());
+						
+						// Clones the speed/direction
+						clonedEntity.setVelocity(initialProjectileVelocity);
+						
+						// Just in case
+						event.getEntity().remove();
+					}
+				}, 1L);
+				
+				// Teleports back the spectators
+				Bukkit.getScheduler().runTaskLater(plugin, new BukkitRunnable() {
+					@Override
+					public void run() {
+						for(UUID spectatorUUID : spectatorsAffected) {
+							Player spectator = plugin.getServer().getPlayer(spectatorUUID);
+							
+							spectator.teleport(spectator.getLocation().add(0, -10, 0));
+							spectator.setFlying(oldFlyMode.get(spectatorUUID));
+						}
+					}
+				}, 5L);
+				
+				// Cancels the effect for everyone (because the thrown potion is re-spawned,
+				// avoids a double effect for some players).
+				event.setCancelled(true);
+				
+				// Side note: there is a visual glitch (the players will see a double splash,
+				// the real one plus the splash on the spectator), but the behavior is preserved and
+				// the effect is applied once, on the players.
+			}	
+		}
 	}
 	
 	/**


### PR DESCRIPTION
~~This is an early Pull-Request. Don't merge now!~~
- [x] Cancel hits from all projectiles, potions excepted (`EntityDamageByEntityEvent`).
- [x] Cancel hits from potions (`PotionSplashEvent`).
- [x] ~~Send a message to the spectator to explain why he has been teleported/teleported back.~~

Possible fixes for this (using `EntityDamageByEntityEvent`):
1. Teleport the spectator up two blocks, let the projectile go through, then teleport the spectator back down 2 blocks again.
2. The arrow is teleported to the other side of the spectator, velocity and direction are reset to what they were before the collision with the spectator and it continues on its flight.
3. Use `ProjectileHitEvent` instead (it's called when a projectile hits anything, e.g. wall, ground, mob, player...). However, it doesn't directly show what/who it hit, so it would require the use of `Entity.getNearbyEntities(1,1,1)`, a Vanilla Minecraft method which may have an impact on performance.
4. The first option for all projectiles except potions, and a `PotionSplashEvent`-based fix similar to the first one for potions. This because the `EntityDamageByEntityEvent` does not fire when an entity is hit by a positive or neutral potion.

I'm currently following the fourth idea.
Why not the second one? Because the player who fired must absolutely see the arrow going in the expected location, with a high accuracy.
Teleport the projectile across the spectators does not allow this precision, due to the fact that the path is not straight, but curved.

Currently, when a spectator is hit, I teleport the player up, then I teleport the arrow where it was before the hit, and I reset the velocity. Then I cancel the event.
So there is a visual glitch for the spectator, but the arrow will go in the exact same location as the “normal” location, without a spectator in the middle.

I think that point (exact same behavior for the non-spec players) is the **most important** point here, related to the fix.

---

Oh. Ticket 11, Pull Request #11. Coincidence? I don't think so...
