### PR TITLE
Fixed: effects not removed when a player quits as a spectator.

### DIFF
--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -39,6 +39,7 @@ import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -488,34 +489,20 @@ public class SpectateListener implements Listener {
 	
 	/**
 	 * Used to:<br>
-	 *  - removes the player from the internal scoreboard;<br>
-	 *  - disable the 'hidden' state of the spectator;<br>
-	 *  - put the player back in the server's default gamemode;<br>
-	 *  - disable the spectator mode and reload the inventory, to avoid this inventory to be destroyed on server restart.
+	 *  - disable the spectator mode and reload the inventory, to avoid this inventory to be destroyed on server restart;<br>
+	 *  - save the spectator mode on a file to restore it on the next login.
 	 * 
 	 * @param event
 	 */
 	@EventHandler
 	protected void onPlayerQuit(PlayerQuitEvent event) {
 		Player spectator = event.getPlayer();
-		
-		if (plugin.scoreboard) {
-			plugin.team.removePlayer(spectator);
-		}
-		
-		for (Player target : plugin.getServer().getOnlinePlayers()) {
-			target.showPlayer(event.getPlayer()); // show the leaving player to everyone
-			event.getPlayer().showPlayer(target); // show the leaving player everyone
-		}
-		
 		if (plugin.user.get(spectator.getName()).spectating) {
-			plugin.user.get(spectator.getName()).spectating = false;
-			spectator.setGameMode(plugin.getServer().getDefaultGameMode());
+			plugin.disableSpectate(spectator, plugin.console);
 			
-			plugin.spawnPlayer(spectator);
-			plugin.loadPlayerInv(spectator);
-			
-			plugin.user.remove(spectator.getName());
+			// The spectator mode needs to be re-enabled on the next login
+			plugin.specs.getConfig().set(spectator.getName(), true);
+			plugin.specs.saveConfig();
 		}
 	}
 	

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -712,6 +713,7 @@ public class SpectatorPlus extends JavaPlugin {
 			}
 		}
 	}
+
 
 	protected void reloadConfig(boolean hardReload) {
 		// 'hardReload': true/false; a hard reload will reload the config values from file.


### PR DESCRIPTION
I use the `disableSpectate` method, instead of re-doing (partially, that was the cause of the bug) the stuff needed to disable the spectator mode.

Branch name: `kickFix` because I thought this was a kick-related bug.

[Build here](http://jenkins.carrade.eu/job/SpectatorPlus-AmauryCarrade/3/artifact/SpectatorPlus/target/SpectatorPlus-B2.0.jar).
