### PR TITLE
New spectators' tool: teleportation to death point

### DIFF
--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/PlayerObject.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/PlayerObject.java
@@ -46,6 +46,20 @@ public class PlayerObject {
 	protected GameMode oldGameMode;
 	
 	/**
+	 * The display name of the last killer of the spectator.
+	 * <p>
+	 * Null if never killed.
+	 */
+	protected String lastKiller = null;
+	
+	/**
+	 * The location of the last death.
+	 * 
+	 * Null if no death registered.
+	 */
+	protected Location deathLocation = null;
+	
+	/**
 	 * The setup step.
 	 *  - 0: no setup in progress;
 	 *  - 1: first corner set;

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/PlayerObject.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/PlayerObject.java
@@ -46,11 +46,14 @@ public class PlayerObject {
 	protected GameMode oldGameMode;
 	
 	/**
-	 * The display name of the last killer of the spectator.
+	 * The last death message for this player, with his name replaced by "You",
+	 * and "Name was" replaced by "You were".
 	 * <p>
-	 * Null if never killed.
+	 * Example: « You starved to death ».
+	 * <p>
+	 * Null if the player was never dead.
 	 */
-	protected String lastKiller = null;
+	protected String lastDeathMessage = null;
 	
 	/**
 	 * The location of the last death.

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateAPI.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateAPI.java
@@ -202,6 +202,43 @@ public class SpectateAPI {
 	}
 	
 	/**
+	 * Enables/disables the "teleport to death point" tool.
+	 * 
+	 * @param value True if enabled.
+	 * @param temp If true this change will not be saved in the config file.
+	 * 
+	 * @since 2.0
+	 */
+	public void setTPToDeathTool(boolean value, boolean temp) {
+		if(!temp) {
+			plugin.toggles.getConfig().set("tpToDeathTool", value);
+			plugin.toggles.saveConfig();
+		}
+		
+		plugin.tpToDeathTool = value;
+		plugin.reloadConfig(false);
+	}
+	
+	/**
+	 * Enables/disables the display of the death cause in the
+	 * "teleport to death point" tool.
+	 * 
+	 * @param value True if enabled.
+	 * @param temp If true this change will not be saved in the config file.
+	 * 
+	 * @since 2.0
+	 */
+	public void setShowCauseInTPToDeathTool(boolean value, boolean temp) {
+		if(!temp) {
+			plugin.toggles.getConfig().set("tpToDeathToolShowCause", value);
+			plugin.toggles.saveConfig();
+		}
+		
+		plugin.tpToDeathToolShowCause = value;
+		plugin.reloadConfig(false);
+	}
+	
+	/**
 	 * Enables (or disables) the inspector (book).
 	 * 
 	 * @param value Enabled if true.

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -629,13 +629,21 @@ public class SpectateListener implements Listener {
 		}
 	}
 	
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR)
 	protected void onPlayerDeath(PlayerDeathEvent event) {
-		plugin.user.get(event.getEntity().getName()).deathLocation = event.getEntity().getLocation();
+		Player killed = event.getEntity();
 		
-		if(event.getEntity().getKiller() != null) {
-			plugin.user.get(event.getEntity().getName()).lastKiller = event.getEntity().getKiller().getDisplayName();
-		}
+		plugin.user.get(killed.getName()).deathLocation = killed.getLocation();
+		
+		String deathMessage = ChatColor.stripColor(event.getDeathMessage());
+		String noColorsDisplayName = ChatColor.stripColor(killed.getDisplayName());
+		
+		deathMessage.replace(killed.getName() + " was", "You were")
+		            .replace(killed.getName(), "You")
+		            .replace(noColorsDisplayName + " was", "You were")
+		            .replace(noColorsDisplayName, "You");
+		
+		plugin.user.get(killed.getName()).lastDeathMessage = ChatColor.stripColor(deathMessage);
 	}
 	
 	/**

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -631,19 +631,23 @@ public class SpectateListener implements Listener {
 	
 	@EventHandler(priority = EventPriority.MONITOR)
 	protected void onPlayerDeath(PlayerDeathEvent event) {
-		Player killed = event.getEntity();
-		
-		plugin.user.get(killed.getName()).deathLocation = killed.getLocation();
-		
-		String deathMessage = ChatColor.stripColor(event.getDeathMessage());
-		String noColorsDisplayName = ChatColor.stripColor(killed.getDisplayName());
-		
-		deathMessage.replace(killed.getName() + " was", "You were")
-		            .replace(killed.getName(), "You")
-		            .replace(noColorsDisplayName + " was", "You were")
-		            .replace(noColorsDisplayName, "You");
-		
-		plugin.user.get(killed.getName()).lastDeathMessage = ChatColor.stripColor(deathMessage);
+		if(plugin.tpToDeathTool) {
+			Player killed = event.getEntity();
+			
+			plugin.user.get(killed.getName()).deathLocation = killed.getLocation();
+			
+			if(plugin.tpToDeathToolShowCause) {
+				String deathMessage = ChatColor.stripColor(event.getDeathMessage());
+				String noColorsDisplayName = ChatColor.stripColor(killed.getDisplayName());
+				
+				deathMessage.replace(killed.getName() + " was", "You were")
+				            .replace(killed.getName(), "You")
+				            .replace(noColorsDisplayName + " was", "You were")
+				            .replace(noColorsDisplayName, "You");
+				
+				plugin.user.get(killed.getName()).lastDeathMessage = ChatColor.stripColor(deathMessage);
+			}
+		}
 	}
 	
 	/**

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -28,6 +28,7 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
@@ -628,6 +629,15 @@ public class SpectateListener implements Listener {
 		}
 	}
 	
+	@EventHandler
+	protected void onPlayerDeath(PlayerDeathEvent event) {
+		plugin.user.get(event.getEntity().getName()).deathLocation = event.getEntity().getLocation();
+		
+		if(event.getEntity().getKiller() != null) {
+			plugin.user.get(event.getEntity().getName()).lastKiller = event.getEntity().getKiller().getDisplayName();
+		}
+	}
+	
 	/**
 	 * Used to get the selected item in the various GUIs.
 	 * 
@@ -720,6 +730,9 @@ public class SpectateListener implements Listener {
 							spectator.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0), true);
 							spectator.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, Integer.MAX_VALUE, 0), true);
 						}
+					}
+					else if(toolSelected.getItemMeta().getDisplayName().equalsIgnoreCase(SpectatorPlus.TOOL_TP_TO_DEATH_POINT_NAME)) {
+						spectator.teleport(plugin.user.get(spectator.getName()).deathLocation.setDirection(spectator.getLocation().getDirection()));
 					}
 					
 					spectator.closeInventory();

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -640,10 +640,10 @@ public class SpectateListener implements Listener {
 				String deathMessage = ChatColor.stripColor(event.getDeathMessage());
 				String noColorsDisplayName = ChatColor.stripColor(killed.getDisplayName());
 				
-				deathMessage.replace(killed.getName() + " was", "You were")
-				            .replace(killed.getName(), "You")
-				            .replace(noColorsDisplayName + " was", "You were")
-				            .replace(noColorsDisplayName, "You");
+				deathMessage = deathMessage.replace(killed.getName() + " was", "You were")
+				                           .replace(killed.getName(), "You")
+				                           .replace(noColorsDisplayName + " was", "You were")
+				                           .replace(noColorsDisplayName, "You");
 				
 				plugin.user.get(killed.getName()).lastDeathMessage = ChatColor.stripColor(deathMessage);
 			}

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
@@ -512,9 +512,9 @@ public class SpectatorPlus extends JavaPlugin {
 			ItemStack tpToDeathPoint = new ItemStack(Material.NETHER_STAR);
 			meta = tpToDeathPoint.getItemMeta();
 			meta.setDisplayName(TOOL_TP_TO_DEATH_POINT_NAME);
-			if(user.get(spectator.getName()).lastKiller != null) {
+			if(user.get(spectator.getName()).lastDeathMessage != null) {
 				List<String> lore = new ArrayList<String>();
-				lore.add("" + ChatColor.GRAY + "You where killed by " + user.get(spectator.getName()).lastKiller);
+				lore.add("" + ChatColor.GRAY + user.get(spectator.getName()).lastDeathMessage);
 				meta.setLore(lore);
 			}
 			tpToDeathPoint.setItemMeta(meta);

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
@@ -84,7 +84,7 @@ public class SpectatorPlus extends JavaPlugin {
 	protected final static String TOOL_SPEED_IV_NAME  = ChatColor.AQUA + "Speed IV";
 	protected final static String TOOL_NIGHT_VISION_INACTIVE_NAME = ChatColor.GOLD + "Enable night vision";
 	protected final static String TOOL_NIGHT_VISION_ACTIVE_NAME = ChatColor.DARK_PURPLE + "Disable night vision";
-
+	protected final static String TOOL_TP_TO_DEATH_POINT_NAME = ChatColor.YELLOW + "Go to your death point";
 
 	@Override
 	public void onLoad() {
@@ -431,6 +431,12 @@ public class SpectatorPlus extends JavaPlugin {
 		List<String> activeLore = new ArrayList<String>();
 		activeLore.add("" + ChatColor.GRAY + ChatColor.ITALIC + "Active");
 		
+		// If a death location is registered for this player, the position of the "night vision" tool
+		// is not the same (6 with death point registered; 8 without).
+		// That's why this is defined here, not below.
+		Location deathPoint = user.get(spectator.getName()).deathLocation;
+		
+		
 		// Normal speed
 		ItemStack normalSpeed = new ItemStack(Material.STRING);
 		ItemMeta meta = normalSpeed.getItemMeta();
@@ -493,7 +499,28 @@ public class SpectatorPlus extends JavaPlugin {
 			meta.setDisplayName(TOOL_NIGHT_VISION_INACTIVE_NAME);
 		}
 		nightVision.setItemMeta(meta);
-		GUIContent[8] = nightVision;
+		if(deathPoint == null) { // No "TP to death point" tool: position #8.
+			GUIContent[8] = nightVision;
+		}
+		else {
+			GUIContent[6] = nightVision;
+		}
+		
+		
+		// Teleportation to the death point
+		if(deathPoint != null) { // No "TP to death point" tool: position #8.
+			ItemStack tpToDeathPoint = new ItemStack(Material.NETHER_STAR);
+			meta = tpToDeathPoint.getItemMeta();
+			meta.setDisplayName(TOOL_TP_TO_DEATH_POINT_NAME);
+			if(user.get(spectator.getName()).lastKiller != null) {
+				List<String> lore = new ArrayList<String>();
+				lore.add("" + ChatColor.GRAY + "You where killed by " + user.get(spectator.getName()).lastKiller);
+				meta.setLore(lore);
+			}
+			tpToDeathPoint.setItemMeta(meta);
+			GUIContent[8] = tpToDeathPoint;
+		}
+		
 		
 		
 		gui.setContents(GUIContent);

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
@@ -63,7 +63,7 @@ public class SpectatorPlus extends JavaPlugin {
 	protected String spectatorsToolsItem;
 	protected boolean inspector;
 	protected String inspectorItem;
-	protected boolean inspectFromTPMenu, specChat, scoreboard, output, death, seeSpecs, blockCmds, adminBypass;
+	protected boolean tpToDeathTool, tpToDeathToolShowCause, inspectFromTPMenu, specChat, scoreboard, output, death, seeSpecs, blockCmds, adminBypass;
 
 	protected ScoreboardManager manager = null;
 	protected Scoreboard board = null;
@@ -434,6 +434,8 @@ public class SpectatorPlus extends JavaPlugin {
 		// If a death location is registered for this player, the position of the "night vision" tool
 		// is not the same (6 with death point registered; 8 without).
 		// That's why this is defined here, not below.
+		// If the "tp to death" tool is disabled, the death location is not set. So it's useless to
+		// check this here.
 		Location deathPoint = user.get(spectator.getName()).deathLocation;
 		
 		
@@ -508,10 +510,11 @@ public class SpectatorPlus extends JavaPlugin {
 		
 		
 		// Teleportation to the death point
-		if(deathPoint != null) { // No "TP to death point" tool: position #8.
+		if(deathPoint != null) {
 			ItemStack tpToDeathPoint = new ItemStack(Material.NETHER_STAR);
 			meta = tpToDeathPoint.getItemMeta();
 			meta.setDisplayName(TOOL_TP_TO_DEATH_POINT_NAME);
+			// The death message is never set if it is disabled: check useless (same as above).
 			if(user.get(spectator.getName()).lastDeathMessage != null) {
 				List<String> lore = new ArrayList<String>();
 				lore.add("" + ChatColor.GRAY + user.get(spectator.getName()).lastDeathMessage);
@@ -791,6 +794,17 @@ public class SpectatorPlus extends JavaPlugin {
 				console.sendMessage(ChatColor.GOLD+"Added "+ChatColor.WHITE+"spectatorsToolsItem: book"+ChatColor.GOLD+" to "+ChatColor.WHITE+"toggles.yml"+ChatColor.GOLD+"...");
 			}
 			
+			// Spectators' tool: TP to death: true/false
+			if (!toggles.getConfig().contains("tpToDeathTool")) {
+				toggles.getConfig().set("tpToDeathTool", true);
+				console.sendMessage(ChatColor.GOLD+"Added "+ChatColor.WHITE+"tpToDeathTool: true"+ChatColor.GOLD+" to "+ChatColor.WHITE+"toggles.yml"+ChatColor.GOLD+"...");
+			}
+			// Spectators' tool: TP to death: show death cause true/false
+			if (!toggles.getConfig().contains("tpToDeathToolShowCause")) {
+				toggles.getConfig().set("tpToDeathToolShowCause", true);
+				console.sendMessage(ChatColor.GOLD+"Added "+ChatColor.WHITE+"tpToDeathToolShowCause: true"+ChatColor.GOLD+" to "+ChatColor.WHITE+"toggles.yml"+ChatColor.GOLD+"...");
+			}
+			
 			// Inspector: true/false
 			if (!toggles.getConfig().contains("inspector")) {
 				toggles.getConfig().set("inspector", true);
@@ -856,6 +870,8 @@ public class SpectatorPlus extends JavaPlugin {
 			compass = toggles.getConfig().getBoolean("compass", true);
 			clock = toggles.getConfig().getBoolean("arenaclock", true);
 			spectatorsTools = toggles.getConfig().getBoolean("spectatorsTools", true);
+			tpToDeathTool = toggles.getConfig().getBoolean("tpToDeathTool", true);
+			tpToDeathToolShowCause = toggles.getConfig().getBoolean("tpToDeathToolShowCause", true);
 			inspector = toggles.getConfig().getBoolean("inspector", true);
 			inspectFromTPMenu = toggles.getConfig().getBoolean("inspectPlayerFromTeleportationMenu", true);
 			specChat = toggles.getConfig().getBoolean("specchat", true);

--- a/SpectatorPlus/toggles.yml
+++ b/SpectatorPlus/toggles.yml
@@ -1,12 +1,20 @@
 # Enable the teleporter (compass)?
 compass: true
 compassItem: compass
+
 # Enable the arena selector in arena mode (clock)?
 arenaclock: true
 clockItem: watch
+
 # Enable the spectators' tools (magma cream), to give spectators speed, night or underwater vision?
 spectatorsTools: true
 spectatorsToolsItem: magma_cream
+
+# Enable the "teleport to death point" spectators' tool?
+tpToDeathTool: true
+# Display the cause of the death in the tooltip? (Example: « You starved to death ».)
+tpToDeathToolShowCause: true
+
 # Enable the player inspector (book)?
 inspector: true
 inspectorItem: book


### PR DESCRIPTION
All in the title!

If this feature is disabled (in the config) or if there isn't any saved death point for the spectator, the GUI is just like before. Else, a new item is added.

![2014-09-17_13 37 57](https://cloud.githubusercontent.com/assets/1417570/4304095/b7f936e0-3e6d-11e4-8e77-886cf442e297.png)

The death cause can be hidden (displayed by default).

I use the nether star because this item is like a “target”, with the cross. (And, why not?)
