### PR TITLE
Add a Basic "Skript Integration Fix" Toggle

### DIFF
--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateAPI.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateAPI.java
@@ -215,6 +215,10 @@ public class SpectateAPI {
 				p.scoreboard = (Boolean) value;
 				break;
 				
+			case SKRIPT_INTEGRATION:
+				p.skriptInt = (Boolean) value;
+				break;
+				
 			case SPECTATOR_MODE_ON_DEATH:
 				p.death = (Boolean) value;
 				break;

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -545,7 +545,7 @@ public class SpectateListener implements Listener {
 		
 		// Cancel chest opening animation, doors, anything when the player right clicks.
 		if (p.getPlayerData(e.getPlayer()).spectating) {
-			if(p.skriptInt){
+			if(!p.skriptInt){
 				e.setCancelled(true);
 			}
 			if(e.hasBlock()) {

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectateListener.java
@@ -545,8 +545,9 @@ public class SpectateListener implements Listener {
 		
 		// Cancel chest opening animation, doors, anything when the player right clicks.
 		if (p.getPlayerData(e.getPlayer()).spectating) {
-			e.setCancelled(true);
-			
+			if(p.skriptInt){
+				e.setCancelled(true);
+			}
 			if(e.hasBlock()) {
 				
 				// Opens the inventory of the blocks with an inventory without the opening animation

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/SpectatorPlus.java
@@ -69,7 +69,7 @@ public class SpectatorPlus extends JavaPlugin {
 	protected Material spectatorsToolsItem;
 	protected boolean inspector;
 	protected Material inspectorItem;
-	protected boolean tpToDeathTool, tpToDeathToolShowCause, inspectFromTPMenu, playersHealthInTeleportationMenu, playersLocationInTeleportationMenu, specChat, scoreboard, output, death, seeSpecs, blockCmds, adminBypass, newbieMode, teleportToSpawnOnSpecChangeWithoutLobby, useSpawnCommandToTeleport, enforceArenaBoundary;
+	protected boolean tpToDeathTool, tpToDeathToolShowCause, inspectFromTPMenu, playersHealthInTeleportationMenu, playersLocationInTeleportationMenu, specChat, scoreboard, output, death, seeSpecs, blockCmds, adminBypass, newbieMode, teleportToSpawnOnSpecChangeWithoutLobby, useSpawnCommandToTeleport, enforceArenaBoundary, skriptInt;
 	
 	protected SpectatorMode mode = SpectatorMode.ANY;
 	
@@ -944,6 +944,7 @@ public class SpectatorPlus extends JavaPlugin {
 		death = toggles.getBoolean(Toggle.SPECTATOR_MODE_ON_DEATH);
 		scoreboard = toggles.getBoolean(Toggle.SPECTATORS_TABLIST_PREFIX);
 		seeSpecs = toggles.getBoolean(Toggle.SPECTATORS_SEE_OTHERS);
+		skriptInt = toggles.getBoolean(Toggle.SKRIPT_INTEGRATION);
 		blockCmds = toggles.getBoolean(Toggle.CHAT_BLOCKCOMMANDS_ENABLED);
 		adminBypass = toggles.getBoolean(Toggle.CHAT_BLOCKCOMMANDS_ADMINBYPASS);
 		newbieMode = toggles.getBoolean(Toggle.TOOLS_NEWBIEMODE);

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/Toggle.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/Toggle.java
@@ -51,6 +51,10 @@ public enum Toggle {
 	
 	SPECTATORS_TABLIST_PREFIX("spectators.tabListPrefix", Boolean.class, true, "Prefix spectator names in the tab list? This will change the Scoreboard used, and restore the old one when spectator mode is disabled. If you see another plugin's sidebar/infos on players list disappearing when you enable the spectator mode, try to disable this."),
 	SPECTATORS_SEE_OTHERS("spectators.spectatorsSeeSpectators", Boolean.class, true, "See other spectators when you're spectating? (*requires spectators.tabListPrefix to be true*)"),
+
+	// Skript Integration, for allowing click events...
+	
+	SKRIPT_INTEGRATION("skriptIntegration", Boolean.class, false, "Enable Skript integration? Only set to true if needed."),
 	
 	// What to do when the spectator mode is changed (enabled or disabled)?
 	

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
@@ -149,7 +149,7 @@ public class ToggleManager {
 		}
 		
 		Validate.isTrue(toggle.getDataType().isAssignableFrom(value.getClass()), "Cannot cast the value of this toggle to the correct data type: ", toggle.getPath());
-		toggles.getConfig().set(toggle.getPath(), value);
+		toggles.getConfig().set(toggle.getPath(), value.toString());
 	}
 	
 	/**

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
@@ -228,6 +228,7 @@ public class ToggleManager {
 			conversionTable.put("deathspec", "spectatorModeOnDeath");
 			conversionTable.put("colouredtablist", "spectators.tabListPrefix");
 			conversionTable.put("seespecs", "spectators.spectatorsSeeSpectators");
+			conversionTable.put("skriptInt", "skriptIntegration");
 			conversionTable.put("blockcmds", "chat.blockCommands.enabled");
 			conversionTable.put("adminbypass", "chat.blockCommands.adminBypass");
 			conversionTable.put("newbieMode", "tools.newbieMode");

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
@@ -145,10 +145,11 @@ public class ToggleManager {
 	@SuppressWarnings("unchecked")
 	public void set(Toggle toggle, Object value) {
 		if(value == null) {
-			toggles.getConfig().set(toggle.getPath(), toggle.getDefaultValue());
+			toggles.getConfig().set(toggle.getPath(), toggle.getDefaultValue().toString());
 		}
 		
 		Validate.isTrue(toggle.getDataType().isAssignableFrom(value.getClass()), "Cannot cast the value of this toggle to the correct data type: ", toggle.getPath());
+		
 		toggles.getConfig().set(toggle.getPath(), value.toString());
 	}
 	
@@ -184,8 +185,6 @@ public class ToggleManager {
 	 * appropried default values.
 	 */
 	protected void upgrade() {
-		p.getLogger().info("Upgrading toggles from version " + getVersion() + " to " + p.version + "...");
-		
 		Set<String> togglesND = getConfiguration().getKeys(true); // ND = no defaults
 		
 		for(Toggle toggle : Toggle.values()) {

--- a/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
+++ b/SpectatorPlus/src/com/pgcraft/spectatorplus/ToggleManager.java
@@ -228,7 +228,6 @@ public class ToggleManager {
 			conversionTable.put("deathspec", "spectatorModeOnDeath");
 			conversionTable.put("colouredtablist", "spectators.tabListPrefix");
 			conversionTable.put("seespecs", "spectators.spectatorsSeeSpectators");
-			conversionTable.put("skriptInt", "skriptIntegration");
 			conversionTable.put("blockcmds", "chat.blockCommands.enabled");
 			conversionTable.put("adminbypass", "chat.blockCommands.adminBypass");
 			conversionTable.put("newbieMode", "tools.newbieMode");

--- a/SpectatorPlus/toggles.yml
+++ b/SpectatorPlus/toggles.yml
@@ -80,6 +80,10 @@ onSpectatorModeChanged:
         usingSpawnCommand: true
 
 
+# Enable Skript integration? Only set to true if needed.
+skriptIntegration: false
+
+
 # Show spectatorplus plugin messages to spectators?
 outputMessages: true
 


### PR DESCRIPTION
This is kind of poorly made (new to java), so it probably misses
something and may cause some bugs. But the reason is the following: In
the SpectateListener, the general cancel on click events impedes Skript
to handle it, thus disallowing for custom menu items (like a leave
"button"). Thus, I first tried removing that single cancelation, and it
actually worked, but I wanted to make it an optional toggle, and commit
it to the original plugin, so more people can enjoy this plugin in a
more customized way :)

As mentioned in the yml option, this option should only be set to true
if you're going to use Skript, or another plugin that will cancel and
handle the click event. Otherwise, you'd allow people to interact with
the world...

Still not 100% sure this will work properly, I'm open to suggestions :)